### PR TITLE
Convert imports to relative

### DIFF
--- a/mrnaid/backend/flask_app/Makefile
+++ b/mrnaid/backend/flask_app/Makefile
@@ -21,7 +21,6 @@ uwsgi-run:
 	CELERY_RESULT_BACKEND=redis://127.0.0.1:6379 \
 	LOG_FILE=./logs/logs.log \
 	BACKEND_OBJECTIVES_DATA=../common/objectives/data \
-	PYTHONPATH=../common:../common/objectives:../common/constraints:../common/arw_mrna/src \
 	uwsgi --ini app.ini:uwsgi-docker
 
 flask-run:
@@ -36,7 +35,6 @@ celery-run:
 		CELERY_RESULT_BACKEND=redis://127.0.0.1:6379 \
 		LOG_FILE=./logs/logs.log \
 		BACKEND_OBJECTIVES_DATA=../common/objectives/data \
-		PYTHONPATH=../common:../common/objectives:../common/constraints:../common/arw_mrna/src \
 		python -m celery -A tasks worker --loglevel=info
 
 flower-run:

--- a/mrnaid/backend/flask_app/routes.py
+++ b/mrnaid/backend/flask_app/routes.py
@@ -1,20 +1,17 @@
 import json
-
 from flask import Flask, request, render_template, jsonify
-from tasks import optimization_evaluation_task, ARWA, arwa_generator_task
 from flask_socketio import SocketIO, emit
 from flask_cors import CORS
-from utils.Exceptions import EmptySequenceError, SequenceLengthError, NoGCError, EntropyWindowError, \
-    NumberOfSequencesError, WrongCharSequenceError, RangeError, SpeciesError
-from utils.Logger import MyLogger
-from utils.RequestParser import RequestParser
 import pickle
-import protein
-import awalk
-import vienna
-import objective_functions as objectives
+from .tasks import optimization_evaluation_task, arwa_generator_task
+from ..common.utils.Exceptions import EmptySequenceError, SequenceLengthError, NoGCError, EntropyWindowError, \
+    NumberOfSequencesError, WrongCharSequenceError, RangeError, SpeciesError
+from ..common.utils.Logger import MyLogger
+from ..common.utils.RequestParser import RequestParser
+from ..common.arw_mrna.src import protein, awalk, vienna, objective_functions as objectives
+import python_codon_tables
 from os import getcwd, path
-from notify import send_email
+from .notify import send_email
 app = Flask(__name__)
 socketio = SocketIO(app)
 CORS(app)

--- a/mrnaid/backend/flask_app/tasks.py
+++ b/mrnaid/backend/flask_app/tasks.py
@@ -1,23 +1,15 @@
 import json
 import os
-import time
 import numpy as np
-from Evaluation import Evaluation
-from OptimizationProblems import initialize_optimization_problem
-from OptimizationTask import optimization_task
 from billiard import Pool
 from celery import Celery
-from utils.Datatypes import OptimizationParameters
-from utils.Logger import MyLogger
-from awalk import adaptive_random_walk, WalkConfig
-from importlib import util
-import sys
-from pathlib import Path
 import pickle
-import protein
-import awalk
-import vienna
-import objective_functions as objectives
+from ..common.Evaluation import Evaluation
+from ..common.OptimizationProblems import initialize_optimization_problem
+from ..common.OptimizationTask import optimization_task
+from ..common.utils.Datatypes import OptimizationParameters
+from ..common.utils.Logger import MyLogger
+from ..common.arw_mrna.src import protein, awalk, vienna, objective_functions as objectives
 
 # Setting up logger
 logger = MyLogger(__name__)


### PR DESCRIPTION
This removes the need for pythonpath variable

And works better with vscode and removes a lot of complexity, especially because there is a module in arw_mrna and common folder with the same name